### PR TITLE
Modification connexion + redirection après mdp oublié

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -8,7 +8,7 @@ security:
         app_user_provider:
             entity:
                 class: App\Entity\User
-                property: email
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -119,7 +119,7 @@ class ResetPasswordController extends AbstractController
             // The session is cleaned up after the password has been changed.
             $this->cleanSessionAfterReset();
 
-            return $this->redirectToRoute('main/accueil.html.twig');
+            return $this->redirectToRoute('app_login');
         }
 
         return $this->render('reset_password/reset.html.twig', [
@@ -157,7 +157,7 @@ class ResetPasswordController extends AbstractController
         $email = (new TemplatedEmail())
             ->from(new Address('enisortir@campus-eni.fr', 'ENI SORTIR'))
             ->to($user->getEmail())
-            ->subject('Your password reset request')
+            ->subject('Votre demande de réinitialisation de mot de passe')
             ->htmlTemplate('reset_password/email.html.twig')
             ->context([
                 'resetToken' => $resetToken,

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -13,6 +13,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[UniqueEntity(fields: ['email'], message: 'Il existe déjà un compte avec cet email')]
+#[UniqueEntity(fields: ['pseudo'], message: 'Ce pseudo est déjà utilisé')]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
  * @method User[]    findAll()
  * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface, UserLoaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -54,6 +55,20 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $user->setPassword($newHashedPassword);
 
         $this->save($user, true);
+    }
+
+    public function loadUserByIdentifier(string $usernameOrEmail): ?User
+    {
+        $entityManager = $this->getEntityManager();
+
+        return $entityManager->createQuery(
+            'SELECT u
+            FROM App\Entity\User u
+            WHERE u.pseudo = :query
+            OR u.email = :query'
+        )
+        ->setParameter('query', $usernameOrEmail)
+        ->getOneOrNullResult();
     }
 
 //    /**

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -22,7 +22,7 @@
     </header>
     <div class="header_home">
         {% if  app.user%}
-            <a href="">Accueil</a>
+            <a href="{{ path('_main_sorties') }}">Accueil</a>
             <a href="{{ path('profil_modif') }}">Mon profil</a>
             <a href="{{ path('app_logout') }}" title="logout">Se deconnecter</a>
 {#            <p>Hello {{ app.user.prenom }}</p>#}

--- a/templates/main/sorties.html.twig
+++ b/templates/main/sorties.html.twig
@@ -73,7 +73,7 @@
                         {%  endif %}
                     {% endfor %}
                 </div>
-                <div>{{ sortie.organisteur.nom }}</div>
+                <div>{{ sortie.organisateur.nom }}</div>
                 <div>Actions TODO</div>
             {% endfor %}
     </div>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -16,7 +16,7 @@
 
     <h1 class="h3 mb-3 font-weight-normal">Connexion</h1>
     <label for="inputEmail">Email : </label>
-    <input type="email" value="{{ last_username }}" name="email" id="inputEmail" class="form-control" autocomplete="email" required autofocus>
+    <input type="text" value="{{ last_username }}" name="email" id="inputEmail" class="form-control" autocomplete="email" required autofocus>
     <label for="inputPassword">Mot de passe : </label>
     <input type="password" name="password" id="inputPassword" class="form-control" autocomplete="current-password" required>
 


### PR DESCRIPTION
- Dans UserRepository.php ajout de la méthode de connexion avec l'email ou le pseudo
- Dans security.yaml suppression de la propriété de connexion QUE avec l'email
- Dans login.html.twig modification du type de l'input pour que ce ne soit pas que un champ email
- Dans User.php ajout de la contrainte pseudo unique
- Dans ResetPasswordController.php modification de la redirection vers le login après le reset du mot de passe
- Dans base.html.twig ajout de la route vers main/sorties au niveau du boutton Accueil de la nav
- Dans sorties.html.twig correction de organister à organisateur